### PR TITLE
Added input to 'generate_scratchblocks' to allow customized blocks

### DIFF
--- a/blocks.py
+++ b/blocks.py
@@ -125,6 +125,18 @@ BLOCKS = {
     # My Blocks
     "procedures_definition": ("define {}", ["custom_block"]),
     "procedures_call": custom_block,
+
+    # Pen
+    "pen_clear": ("erase all", []),
+    "pen_stamp": ("stamp", []),
+    "pen_penDown": ("pen down", []),
+    "pen_penUp": ("pen up", []),
+    "pen_setPenColorToColor": ("set pen color to {}", ["COLOR"]),
+    "pen_changePenColorParamBy": ("change pen ({} v) by {}", ["COLOR_PARAM", "VALUE"]),
+    "pen_setPenColorParamTo": ("set pen ({} v) to {}", ["COLOR_PARAM", "VALUE"]),
+    "pen_changePenSizeBy": ("change pen size by {}", ["SIZE"]),
+    "pen_setPenSizeTo": ("set pen size to {}", ["SIZE"]),
+
 }
 
 INPUTS = {
@@ -201,6 +213,9 @@ INPUTS = {
     "procedures_prototype": custom_block,
     "argument_reporter_boolean": ("<{}>", [["VALUE", {}]]),
     "argument_reporter_string_number": ("({})", [["VALUE", {}]]),
+
+    # Pen
+    "pen_menu_colorParam": ("{}", [["colorParam", FIELDS]]),
 }
 
 
@@ -218,7 +233,7 @@ def get_project_from_url(url):
     return res.json()
 
 
-def generate_scratchblocks(project, surrounding):
+def generate_scratchblocks(project):
     """Generates all blocks in a project.
     
     Args:
@@ -238,7 +253,7 @@ def generate_scratchblocks(project, surrounding):
                 and block["opcode"] in BLOCKS
             )
             if is_start:
-                script = generate_script(block_id, target["blocks"], surrounding)
+                script = generate_script(block_id, target["blocks"])
                 scripts.append(script)
     return scripts
 

--- a/blocks.py
+++ b/blocks.py
@@ -137,6 +137,27 @@ BLOCKS = {
     "pen_changePenSizeBy": ("change pen size by {}", ["SIZE"]),
     "pen_setPenSizeTo": ("set pen size to {}", ["SIZE"]),
 
+    # Music
+    "music_playDrumForBeats": ("play drum ({} v) for {} beats", ["DRUM", "BEATS"]),
+    "music_restForBeats": ("rest for {} beats", ["BEATS"]),
+    "music_playNoteForBeats": ("play note ({}) for {} beats", ["NOTE", "BEATS"]), 
+    "music_setInstrument": ("set instrument to ({} v)", ["INSTRUMENT"]),
+    "music_setTempo": ("set tempo to {}", ["TEMPO"]),
+    "music_changeTempo": ("change tempo by {}", ["TEMPO"]),
+
+    # Video
+    "videoSensing_whenMotionGreaterThan": ("when video motion > {}", ["REFERENCE"]),
+    "videoSensing_videoToggle": ("turn video ({} v)", ["VIDEO_STATE"]),
+    "videoSensing_setVideoTransparency": ("set video transparency to {}", ["TRANSPARENCY"]),
+
+    # Text to Speech
+    "text2speech_speakAndWait": ("speak {}", ["WORDS"]),
+    "text2speech_setVoice": ("set voice to ({} v)", ["VOICE"]),
+    "text2speech_setLanguage": ("set language to ({} v)", ["LANGUAGE"]),
+
+    # Translate
+    "translate_getTranslate": ("translate {} to ({} v)", ["WORDS", "LANGUAGE"]),
+
 }
 
 INPUTS = {
@@ -216,6 +237,26 @@ INPUTS = {
 
     # Pen
     "pen_menu_colorParam": ("{}", [["colorParam", FIELDS]]),
+
+    # Music
+    "music_menu_DRUM": ("{}", [["DRUM", FIELDS]]),
+    "note": ("{}", [["NOTE", FIELDS]]),
+    "music_menu_INSTRUMENT": ("{}", [["INSTRUMENT", FIELDS]]),
+    "music_getTempo": ("(tempo)", []),
+
+    # Video
+    "videoSensing_menu_VIDEO_STATE": ("{}", [["VIDEO_STATE", FIELDS]]),
+    "videoSensing_videoOn": ("(video ({} v) on ({} v))", ["ATTRIBUTE", "SUBJECT"]),
+    "videoSensing_menu_ATTRIBUTE": ("{}", [["ATTRIBUTE", FIELDS]]),
+    "videoSensing_menu_SUBJECT": ("{}", [["SUBJECT", FIELDS]]),
+
+    # Text to Speech
+    "text2speech_menu_voices": ("{}", [["voices", FIELDS]]),
+    "text2speech_menu_languages": ("{}", [["languages", FIELDS]]),
+
+    # Translate
+    "translate_menu_languages": ("{}", [["languages", FIELDS]]),
+    "translate_getViewerLanguage": ("language", []),
 }
 
 

--- a/blocks.py
+++ b/blocks.py
@@ -218,12 +218,12 @@ def get_project_from_url(url):
     return res.json()
 
 
-def generate_scratchblocks(project):
+def generate_scratchblocks(project, surrounding):
     """Generates all blocks in a project.
     
     Args:
         project (dict): the Scratch project to process.
-
+        surrounding (list): list of blocks allowed to added
     Returns:
         A list of scripts in the project that can be turned into text.
     """
@@ -238,7 +238,7 @@ def generate_scratchblocks(project):
                 and block["opcode"] in BLOCKS
             )
             if is_start:
-                script = generate_script(block_id, target["blocks"])
+                script = generate_script(block_id, target["blocks"], surrounding)
                 scripts.append(script)
     return scripts
 


### PR DESCRIPTION
Added an input of "surrounding" (the output of get_surrounding_blocks from ccl-scratch-tools) in the function 'generate_scratchblocks' to allow 'generate_script'  to know which blocks to allow -- let me know if this is different logic to what you were thinking @jsarchibald !